### PR TITLE
A few things

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,22 +1,22 @@
 {
-  "presets": [["env", {"modules": false}], "react"],
-  "plugins": [
-    "external-helpers",
-    [
-      "transform-react-remove-prop-types",
-      { "mode": "wrap" }
-    ]
-  ],
   "env": {
+    "development": {
+      "presets": [["env", {"modules": false}], "react"],
+      "plugins": [
+        "external-helpers",
+        ["transform-react-remove-prop-types", {"mode": "wrap"}]
+      ]
+    },
     "test": {
       "presets": [["env"], "react"]
     },
     "production": {
+      "presets": [["env", {"modules": false}], "react"],
       "plugins": [
         "external-helpers",
         [
           "transform-react-remove-prop-types",
-          { "mode": "remove", "removeImport": true }
+          {"mode": "remove", "removeImport": true}
         ]
       ]
     }

--- a/.babelrc
+++ b/.babelrc
@@ -5,7 +5,13 @@
       "presets": [["env"], "react"]
     },
     "production": {
-      "plugins": ["external-helpers"]
+      "plugins": [
+        "external-helpers",
+        [
+          "transform-react-remove-prop-types",
+          { "mode": "remove", "removeImport": true }
+        ]
+      ]
     }
   }
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,5 +1,12 @@
 {
   "presets": [["env", {"modules": false}], "react"],
+  "plugins": [
+    "external-helpers",
+    [
+      "transform-react-remove-prop-types",
+      { "mode": "wrap" }
+    ]
+  ],
   "env": {
     "test": {
       "presets": [["env"], "react"]

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 node_modules
 dist
+package-lock.json
+package-lock.json.*
+yarn.lock

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@ node_modules
 dist
 package-lock.json
 package-lock.json.*
-yarn.lock

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "NODE_ENV=production rollup -c",
-    "clean": "rm dist/*",
+    "clean": "rimraf dist/*",
     "test": "jest",
     "test:watch": "jest --watch",
     "prerelease": "npm run test && npm run build",
@@ -38,6 +38,7 @@
     "react": "16.x",
     "react-dom": "16.x",
     "regenerator-runtime": "0.11.1",
+    "rimraf": "^2.6.2",
     "rollup": "0.56.0",
     "rollup-plugin-babel": "3.0.3",
     "rollup-plugin-commonjs": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   },
   "devDependencies": {
     "babel-plugin-external-helpers": "6.22.0",
+    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "enzyme": "3.3.0",

--- a/package.json
+++ b/package.json
@@ -22,14 +22,13 @@
     "testRegex": "[.]test[.]js",
     "setupTestFrameworkScriptFile": "./tests/setup-tests.js"
   },
-  "dependencies": {},
   "peerDependencies": {
     "prop-types": "15.x",
     "react": "16.x"
   },
   "devDependencies": {
     "babel-plugin-external-helpers": "6.22.0",
-    "babel-plugin-transform-react-remove-prop-types": "^0.4.13",
+    "babel-plugin-transform-react-remove-prop-types": "0.4.13",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
     "enzyme": "3.3.0",
@@ -39,7 +38,7 @@
     "react": "16.x",
     "react-dom": "16.x",
     "regenerator-runtime": "0.11.1",
-    "rimraf": "^2.6.2",
+    "rimraf": "2.6.2",
     "rollup": "0.56.0",
     "rollup-plugin-babel": "3.0.3",
     "rollup-plugin-commonjs": "8.3.0",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-plugin-transform-react-remove-prop-types": "0.4.13",
     "babel-preset-env": "1.6.1",
     "babel-preset-react": "6.24.1",
+    "cross-env": "5.1.3",
     "enzyme": "3.3.0",
     "enzyme-adapter-react-16": "1.1.1",
     "jest": "22.3.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
   ],
   "scripts": {
     "prebuild": "npm run clean",
-    "build": "NODE_ENV=production rollup -c",
+    "build": "npm run build:dev && npm run build:prod",
+    "build:dev": "rollup -c",
+    "build:prod": "cross-env NODE_ENV=production rollup -c",
     "clean": "rimraf dist/*",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,6 +4,8 @@ import babel from 'rollup-plugin-babel';
 import uglify from 'rollup-plugin-uglify';
 import pkg from './package.json';
 
+const NODE_ENV = process.env.NODE_ENV || 'development';
+
 function minify(config) {
   return Object.assign({}, config, {
     output: Object.assign({}, config.output, {
@@ -48,4 +50,6 @@ const esConfig = Object.assign({}, baseConfig, {
   output: {file: pkg.module, format: 'es'},
 });
 
-export default [umdConfig, minify(umdConfig), cjsConfig, esConfig];
+export default (NODE_ENV === 'production'
+  ? [minify(umdConfig)]
+  : [umdConfig, cjsConfig, esConfig]);

--- a/yarn.lock
+++ b/yarn.lock
@@ -624,6 +624,10 @@ babel-plugin-transform-react-jsx@^6.24.1:
     babel-plugin-syntax-jsx "^6.8.0"
     babel-runtime "^6.22.0"
 
+babel-plugin-transform-react-remove-prop-types@0.4.13:
+  version "0.4.13"
+  resolved "https://registry.yarnpkg.com/babel-plugin-transform-react-remove-prop-types/-/babel-plugin-transform-react-remove-prop-types-0.4.13.tgz#331cfc05099a808238311d78319c27460d481189"
+
 babel-plugin-transform-regenerator@^6.22.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz#e0703696fbde27f0a3efcacf8b4dca2f7b3a8f2f"
@@ -3068,7 +3072,7 @@ right-align@^0.1.1:
   dependencies:
     align-text "^0.1.1"
 
-rimraf@2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
+rimraf@2, rimraf@2.6.2, rimraf@^2.5.1, rimraf@^2.5.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -972,7 +972,14 @@ core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
 
-cross-spawn@^5.0.1:
+cross-env@5.1.3:
+  version "5.1.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-5.1.3.tgz#f8ae18faac87692b0a8b4d2f7000d4ec3a85dfd7"
+  dependencies:
+    cross-spawn "^5.1.0"
+    is-windows "^1.0.0"
+
+cross-spawn@^5.0.1, cross-spawn@^5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
   dependencies:
@@ -1824,6 +1831,10 @@ is-typedarray@~1.0.0:
 is-utf8@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
+
+is-windows@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
 
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
- Swaps in `rimraf`. Presently, `npm run build` will error out if you do not already have a `dist` directory. Most new contributors will not have a `list` directory, which makes it hard for them to build the lib to see what the result is! There are ways to do this by writing a fancier shell script, but rimraf is nice because it supports many different operating systems.

  I am happy to replace this with another solution if you'd prefer. Let me know!

- Adds lock files to the gitignore. Self-explanatory, I guess. I can remove this commit if you prefer.

- Removes prop-types from production builds. This reduces the file size from `792 B` to `728 B`, which is roughly a 10% file size reduction.

  I didn't look too closely at the build step to determine if there are situations when you might want the prop types to remain in the production build.

Thanks for reviewing! :v: